### PR TITLE
Added a workflow for automatic tagging on publish

### DIFF
--- a/.github/workflows/create-tag-on-publish.yml
+++ b/.github/workflows/create-tag-on-publish.yml
@@ -1,0 +1,27 @@
+name: Tag on Publish
+
+on:
+  push:
+    branches:
+      - xtext-website 
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Set up date for tag
+        id: get_date
+        run: echo "TAG_DATE=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: "published${{ env.TAG_DATE }}"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME


### PR DESCRIPTION
# Explanation of the GitHub Actions Workflow: Tag on Publish

The Tag on Publish workflow I created is designed to automatically create a Git tag whenever changes are pushed to a specified branch that represents the published version of the website. This automation serves to document and track changes to the website over time, enhancing version control and facilitating easier rollbacks if necessary.
Workflow Breakdown

- **Trigger Event**: The workflow is triggered by a push event to a specified branch (e.g., published). This ensures that the tag creation only occurs when actual changes are made to the published version of the website.

- **Checkout the Repository**: The workflow starts by checking out the repository code using the `actions/checkout@v2` action. This gives the workflow access to the latest codebase to create the tag.

- **Set Up Date for Tag**: A step is included to generate a timestamp in the format `YYYYMMDDHHMM`, which captures the exact date and time when the tag is created. This timestamp is stored in the environment variable `TAG_DATE`.

- **Create and Push Tag**: The final step creates a new Git tag using the generated timestamp. The tag is formatted as `publishedYYYYmmddhhmm`, effectively documenting the version of the website at that specific moment. The tag is then pushed to the remote repository.
  
Git configuration is performed to set the user name and email for the tag creation, using the GitHub Actions bot identity.

## Conclusion

Implementing this GitHub Actions workflow effectively addresses the issue of documenting changes to the website by ensuring that a new tag is created automatically whenever updates are made to the published branch. This not only enhances the management of the codebase but also improves collaboration among developers, as everyone can easily see the history of changes made to the website.