### PR TITLE
Don't specify jnlp image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,6 @@ kind: Pod
 spec:
   containers:
   - name: jnlp
-    image: 'eclipsecbi/jenkins-jnlp-agent'
-    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
     volumeMounts:
     - mountPath: /home/jenkins/.ssh
       name: volume-known-hosts


### PR DESCRIPTION
It's not required and can cause issues if the image is ever renamed or removed.

Fix for one of the issues mentioned in[ Jenkins is broken #3272 ](https://github.com/eclipse-xtext/xtext/issues/3272#issuecomment-2508294367).