### PR TITLE
Added a Workflow for Automatic Tagging on Publish

### DIFF
--- a/.github/workflows/create-tag-on-publish.yml
+++ b/.github/workflows/create-tag-on-publish.yml
@@ -1,0 +1,27 @@
+name: Tag on Publish
+
+on:
+  push:
+    branches:
+      - xtext-website 
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Set up date for tag
+        id: get_date
+        run: echo "TAG_DATE=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
+
+      - name: Create and push tag
+        env:
+          TAG_NAME: "published${{ env.TAG_DATE }}"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME 


### PR DESCRIPTION
As per issue #1 

cc
@szarnekow 
@LorenzoBettini 

I created a new directory `.github/workflows` into which i included the `create-tag-on-publish` file containing a workflow for automatic tagging on publish, designed to automatically create a Git tag whenever changes are pushed to a specified branch that represents the published version of the website. This automation serves to document and track changes to the website over time, enhancing version control and facilitating easier rollbacks if necessary.

## Conclusion

Implementing this GitHub Actions workflow effectively addresses the issue of documenting changes to the website by ensuring that a new tag is created automatically whenever updates are made to the published branch. This not only enhances the management of the codebase but also improves collaboration among developers, as everyone can easily see the history of changes made to the website.