### PR TITLE
Community page updates

### DIFF
--- a/xtext-website/community.html
+++ b/xtext-website/community.html
@@ -9,16 +9,16 @@ title: Community
 			<div class="row">
 				<div class="span1">&nbsp;</div>
 				<div class="span9 team">
-					<a href="https://www.eclipse.org/forums/index.php?t=thread&frm_id=27" class="anchor-in-div"></a>
+					<a href="https://github.com/eclipse-xtext/xtext/discussions" class="anchor-in-div"></a>
 					<div class="row">
 						<div class="span1 ">
 							<img src="{{ site.baseurl }}/images/discussion-circ-darkgray.png" alt="image" class="image_left">
 						</div>
 						<div class="span2 ">
-							<h3>Forum</h3>
+							<h3>GitHub Discussions</h3>
 						</div>
 					<div class="span6 ">
-						<p>The <strong>Xtext&#x2122; forum</strong> is the first source for getting answers in case you got stuck.
+						<p><strong>Xtext&#x2122; GitHub Discussions</strong> is the first source for getting answers in case you got stuck.
 						The community is very friendly.</p>
 					</div>
 					</div>
@@ -76,6 +76,24 @@ title: Community
 						<div class="span6 ">
 							<p>If you are on twitter and want to get notified about Xtext&#x2122;, you should consider following <strong>@Xtext</strong>.</p>
 						</div>
+					</div>
+				</div>
+				<div class="span1">&nbsp;</div>
+			</div>
+			<div class="row">
+				<div class="span1">&nbsp;</div>
+				<div class="span9 team">
+					<a href="https://www.eclipse.org/forums/index.php?t=thread&frm_id=27" class="anchor-in-div"></a>
+					<div class="row">
+						<div class="span1 ">
+							<img src="{{ site.baseurl }}/images/discussion-circ-darkgray.png" alt="image" class="image_left">
+						</div>
+						<div class="span2 ">
+							<h3>Forum (archived)</h3>
+						</div>
+					<div class="span6 ">
+						<p>The <strong>Xtext&#x2122; forum</strong>, now read-only, is still a useful resource, as it contains several years' worth of discussion about Xtext.</p>
+					</div>
 					</div>
 				</div>
 				<div class="span1">&nbsp;</div>

--- a/xtext-website/community.html
+++ b/xtext-website/community.html
@@ -37,7 +37,7 @@ title: Community
 							<h3>Found a Bug?</h3>
 						</div>
 					<div class="span6 ">
-						<p>Bug reports and enhancement request are tracked at <strong>GitHub.org</strong>. Please 
+						<p>Bug reports and enhancement request are tracked at <strong>GitHub.com</strong>. Please
 						explain the problem and provide a reduced but reproducible example.</p>
 					</div>
 					</div>
@@ -53,7 +53,7 @@ title: Community
 							<img src="{{ site.baseurl }}/images/github-mark-darkgray.png" alt="image" class="image_left">
 						</div>
 						<div class="span2 ">
-							<h3>Github</h3>
+							<h3>GitHub</h3>
 						</div>
 						<div class="span6 ">
 							<p>The Xtext&#x2122; source code is available on <strong>GitHub</strong>. You'll find more information on how to contribute to the project in the README.md contained there.</p>


### PR DESCRIPTION
Since the Eclipse Forum is read-only now, I think it is appropriate to point users to GitHub Discussions instead (while still keeping a link to the forum, a very useful Q&A archive).