### PR TITLE
Fix links in the 2.38 release notes

### DIFF
--- a/xtext-website/_posts/releasenotes/2025-03-04-version-2-38-0.md
+++ b/xtext-website/_posts/releasenotes/2025-03-04-version-2-38-0.md
@@ -54,8 +54,8 @@ TODO
 
 As in every release cycle we were eagerly hunting down bugs, and reviewed and integrated plenty of contributions. For further details please refer to the following lists:
 
-* [Fixed GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=is%3Aissue+milestone%3ARelease_2.38+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+* [Fixed GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=is%3Aissue+milestone%3ARelease_2.38+is%3Aclosed+repo%3Aeclipse-xtext%2Fxtext&type=issues&ref=searchresults)
 
-* [Closed Pull Requests](https://github.com/search?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease_2.38+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+* [Closed Pull Requests](https://github.com/search?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease_2.38+is%3Aclosed+repo%3Aeclipse-xtext%2Fxtext&type=pullrequests&ref=searchresults)
 
-* [Fixed Eclipse Bugzilla tickets](https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&classification=Modeling&classification=Tools&columnlist=product%2Ccomponent%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate%2Ckeywords&f0=OP&f1=OP&f3=CP&f4=CP&known_name=Xtext%202.31&list_id=16618269&product=TMF&product=Xtend&query_based_on=Xtext%202.31&query_format=advanced&status_whiteboard=v2.38&status_whiteboard_type=allwordssubstr)
+* [Fixed Eclipse Bugzilla tickets](https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&classification=Modeling&classification=Tools&columnlist=product%2Ccomponent%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate%2Ckeywords&f0=OP&f1=OP&f3=CP&f4=CP&known_name=Xtext%202.38&list_id=16618269&product=TMF&product=Xtend&query_based_on=Xtext%202.38&query_format=advanced&status_whiteboard=v2.38&status_whiteboard_type=allwordssubstr)


### PR DESCRIPTION
Not sure you want to keep the link to Bugzilla, since it's not used anymore. Also if you have some kind of template for these release notes (I couldn't find any in the repo) it might make sense to update the links there too.